### PR TITLE
feat: add SCB_AUTO_{RES|HDR|VRR} for automatic kde display property injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Features:
 * Enables you to define per-game arguments for gamescope
 * Enables you to define global and per-game ENV variables
 * Optionally use scb just for ENV var management
+* Automatically infer display args (output width, height, refresh rate, HDR, or VRR flags) from primary display (KDE only)
 
 ## Documentaion and usage
 Look at https://docs.bazzite.gg/Advanced/scopebuddy/
@@ -29,6 +30,9 @@ Look at https://docs.bazzite.gg/Advanced/scopebuddy/
 * bash
 * [gamescope](https://github.com/ValveSoftware/gamescope)
 * perl
+
+if using `$KDE_AUTO_ARGS`:
+* `jq` (installed by default on Bazzite - other distros may need to install manually)
 
 #### Using curl:
 ```bash

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Features:
 * Enables you to define per-game arguments for gamescope
 * Enables you to define global and per-game ENV variables
 * Optionally use scb just for ENV var management
-* Automatically infer display args (output width, height, refresh rate, HDR, or VRR flags) from primary display (KDE only)
+* Automatically infer display output args (output width, height, refresh rate, HDR, or VRR flags) from primary display (KDE only)
 
 ## Documentaion and usage
 Look at https://docs.bazzite.gg/Advanced/scopebuddy/
@@ -31,8 +31,9 @@ Look at https://docs.bazzite.gg/Advanced/scopebuddy/
 * [gamescope](https://github.com/ValveSoftware/gamescope)
 * perl
 
-if using `$KDE_AUTO_ARGS`:
+if using `$SCB_AUTO_RES`/`$SCB_AUTO_HDR`/`$SCB_AUTO_VRR`:
 * `jq` (installed by default on Bazzite - other distros may need to install manually)
+* KDE Plasma desktop (Gnome support coming soon)
 
 #### Using curl:
 ```bash

--- a/bin/scopebuddy
+++ b/bin/scopebuddy
@@ -15,7 +15,7 @@
 #   "~/.config/scopebuddy/scb.conf" will be created with examples after first run
 # * Serve as a temporary workaround for fixing the steam overlay when using nested gamescope on desktop steam until fixed upstream
 set -eo pipefail
-SCB_VER="1.0.1"
+SCB_VER="1.1.0"
 echo "Running ScopeBuddy version: $SCB_VER"
 
 gamescope_opts=""

--- a/bin/scopebuddy
+++ b/bin/scopebuddy
@@ -38,6 +38,14 @@ SCB_CONFIGDIR="$HOME/.config/scopebuddy"
 # By default we will never be in gamemode
 SCB_GAMEMODE=0
 
+# Default off for SCB_DEBUG
+SCB_DEBUG=${SCB_DEBUG:-0}
+
+# Default off for SCB_AUTO_*
+SCB_AUTO_RES=${SCB_AUTO_RES:-0}
+SCB_AUTO_HDR=${SCB_AUTO_HDR:-0}
+SCB_AUTO_VRR=${SCB_AUTO_VRR:-0}
+
 ###################
 # Helper functions
 ###################
@@ -77,7 +85,7 @@ replace_or_append_arg() {
     fi
     echo "$argstring"
 }
-# Validates capability to run $KDE_AUTO_ARGS
+# Validates capability to run $SCB_AUTO_*
 # Returns 0 and logs if any dependency is missing.
 kde_auto_args_preflight() {
     local missing=""
@@ -94,7 +102,7 @@ kde_auto_args_preflight() {
         missing+="kscreen-doctor not available; "
     fi
     if [ -n "$missing" ]; then
-        echo "SCB_KDE_AUTO_ARGS defined but not all required conditions are met: $missing"
+        echo "An SCB_AUTO_* argument was passed (auto res, auto hdr, auto vrr) but the following dependencies failed: $missing"
         return 1
     fi
     return 0
@@ -123,7 +131,7 @@ kde_get_primary_display() {
         '
     fi
 }
-# Selectively extracts mode info from kscreen doctor for use with KDE_AUTO_ARGS.
+# Selectively extracts mode info from kscreen doctor for use with SCB_AUTO_*.
 # More fields are available on the mode, the jq selection can be updated if more
 # fields are needed later.
 kde_get_mode_info() {
@@ -255,7 +263,6 @@ else
 #SCB_AUTO_RES=1
 #SCB_AUTO_HDR=1
 #SCB_AUTO_VRR=1
-#SCB_AUTO_FRAME_LIMIT=1
 # To debug scopebuddy output, uncomment the following line. After launching games, the executed cmd will be output to ~/.config/scopebuddy/scopebuddy.log
 #SCB_DEBUG=1
 ###

--- a/bin/scopebuddy
+++ b/bin/scopebuddy
@@ -96,6 +96,8 @@ if [ -f "$SCB_CONFIGFILE" ]; then
         gamescope_opts=$SCB_GAMESCOPE_ARGS
     fi
 
+    # Helper func to fail fast if the user is trying to set KDE_AUTO_ARGS
+    # but doesn't have the right pre-reqs installed or isn't in KDE.
     kde_auto_args_preflight() {
         if [ -z "$SCB_KDE_AUTO_ARGS" ]; then
             return 1
@@ -120,80 +122,46 @@ if [ -f "$SCB_CONFIGFILE" ]; then
         return 0
     }
 
-    # Don't bother trying to do KDE auto arg stuff unless we're in a KDE session,
-    # and have the env var specified and the deps installed.
     if kde_auto_args_preflight; then
-        kde_get_current_mode_id() {
-            kde_get_screen_info | jq -r '
+        # if multidisplay, sort to get the "primary". KDE settings uses 
+        # a boolean style "primary" toggle, but kscreen uses each display 
+        # with a "priority" int.
+        kde_get_primary_display() {
+            kscreen-doctor -j | jq -c '
                 if (.outputs | length) == 1 then
-                    .outputs[0].currentModeId
+                    .outputs[0]
                 else
-                    .outputs[] | select(.enabled == true and .primary == true) | .currentModeId
+                    (.outputs | map(select(.enabled == true)) | sort_by(.priority))[0]
                 end
             '
         }
-
         kde_get_mode_info() {
-            local mode_id="$1"
-            kde_get_screen_info | jq -r --arg mode_id "$mode_id" '
-                if (.outputs | length) == 1 then
-                    .outputs[0].modes[] | select(.id == $mode_id) | {width: .size.width, height: .size.height, refresh: .refreshRate}
-                else
-                    .outputs[] | select(.enabled == true and .primary == true) | .modes[] | select(.id == $mode_id) | {width: .size.width, height: .size.height, refresh: .refreshRate}
-                end
+            mode_id=$(kde_get_primary_display | jq -r '.currentModeId')
+            kde_get_primary_display | jq -r --arg mode_id "$mode_id" '
+                .modes[] | select(.id == $mode_id) | {width: .size.width, height: .size.height, refresh: .refreshRate}
             '
         }
-        kde_get_hdr_state() {
-          kde_get_screen_info | jq -r '.outputs[] | select(.enabled == true) | .hdr'
-        }
-
-        # Function to get the VRR (adaptive sync) state of the enabled display
-        kde_get_vrr_state() {
-          kde_get_screen_info | jq -r '.outputs[] | select(.enabled == true) | .vrrPolicy'
-        }
-
-        # Function to get current screen information in JSON format
-        kde_get_screen_info() {
-          kscreen-doctor -j
-        }
-
-        # Extract width, height, and refresh rate from mode info for the enabled output
-        kde_get_width() {
-          echo "$1" | jq -r '.width'
-        }
-
-        kde_get_height() {
-          echo "$1" | jq -r '.height'
-        }
-
-        kde_get_refresh_rate() {
-          echo "$1" | jq -r '.refresh'
-        }
-        mode_id=$(kde_get_current_mode_id)
-        mode_info=$(kde_get_mode_info "$mode_id")
-
-        KDE_WIDTH=$(kde_get_width "$mode_info")
-        KDE_HEIGHT=$(kde_get_height "$mode_info")
-        KDE_REFRESH=$(kde_get_refresh_rate "$mode_info")
-
-        HDR_STATE=$(kde_get_hdr_state)
-        VRR_STATE=$(kde_get_vrr_state)
+        # hdr and vrr data are stored on the display
+        KDE_HDR_STATE=$(kde_get_primary_display | jq -r '.hdr')
+        KDE_VRR_STATE=$(kde_get_primary_display | jq -r '.vrrPolicy')
+        # width/height/refresh are mode-specifc values
+        KDE_WIDTH=$(kde_get_mode_info | jq -r '.width')
+        KDE_HEIGHT=$(kde_get_mode_info | jq -r '.height')
+        KDE_REFRESH=$(kde_get_mode_info | jq -r '.refresh')
 
         # Remove any existing width (-W), height (-H), or refresh (-r) flags from gamescope_opts.
         # We will replace them with the inferred values from kscreen-doctor in a few lines.
         if [ -n "$gamescope_opts" ]; then
             gamescope_opts=$(echo "$gamescope_opts" | sed -E 's/ *-W[[:space:]]*[0-9]+//g; s/ *-H[[:space:]]*[0-9]+//g; s/ *-r[[:space:]]*[0-9]+//g')
         fi
-
         gamescope_opts="-W $KDE_WIDTH -H $KDE_HEIGHT -r $KDE_REFRESH"
-        if [[ "$HDR_STATE" == "true" ]]; then
+        if [[ "$KDE_HDR_STATE" == "true" ]]; then
             if ! echo "$gamescope_opts" | grep -q -- '--hdr-enabled'; then
                 gamescope_opts="$gamescope_opts --hdr-enabled"
             fi
         fi
-
         # 1 and 2 captures "auto" and "always enabled" vrr modes
-        if [[ "$VRR_STATE" == 1 || "$VRR_STATE" == 2 ]]; then
+        if [[ "$KDE_VRR_STATE" == 1 || "$KDE_VRR_STATE" == 2 ]]; then
             if ! echo "$gamescope_opts" | grep -q -- '--adaptive-sync'; then
                 gamescope_opts="$gamescope_opts --adaptive-sync"
             fi

--- a/bin/scopebuddy
+++ b/bin/scopebuddy
@@ -15,8 +15,12 @@
 #   "~/.config/scopebuddy/scb.conf" will be created with examples after first run
 # * Serve as a temporary workaround for fixing the steam overlay when using nested gamescope on desktop steam until fixed upstream
 set -eo pipefail
+
+##########
+# Globals
+##########
+
 SCB_VER="1.1.0"
-echo "Running ScopeBuddy version: $SCB_VER"
 
 gamescope_opts=""
 command=""
@@ -34,6 +38,100 @@ SCB_CONFIGDIR="$HOME/.config/scopebuddy"
 # By default we will never be in gamemode
 SCB_GAMEMODE=0
 
+###################
+# Helper functions
+###################
+
+# Appends a substring to $gamescope_apts if it doesn't already exist
+# Usage:
+#    gamescope_opts=$(verify_or_append_arg "$gamescope_opts" "<TARGET>")
+# Params:
+#    $1: (Required) original $gamescope_opts argument string, ex: "-H 1920 -W 1080 --mangoapp" 
+#    $2: (Required) target substring. Ex: "--hdr-enabled"). If not found, it will be appended. 
+verify_or_append_arg() {
+    local argstring="$1"
+    local target="$2"
+    # append if the value doesn't exist.
+    if ! echo "$argstring" | grep -F -q -- "$target"; then
+        argstring="$argstring $target"
+    fi
+    echo "$argstring"
+}
+# Uses sed to replace a target string if it exists, or append it to the args if it doesn't.
+# Usage:
+#    gamescope_opts=$(replace_or_append_arg "$gamescope_opts" "<TARGET>" "<REPLACEMENT>")
+# Params:
+#    $1: (Required) original $gamescope_opts argument string, ex: "-H 1920 -W 1080 --mangoapp" 
+#    $2: (Required) target substring. sed extended regex format, ex: "-H[[:space:]]*[0-9]+" (matches strings like "-H 1920") 
+#    $3: (Required) replacement substring. Ex: "-H 3440". If $target is not found, this value will be appended.
+replace_or_append_arg() {
+    local argstring="$1"
+    local target="$2"
+    local replacement="$3"
+    if echo "$argstring" | grep -E -q -- "$target"; then
+        # Replace all occurrences of the target with the replacement.
+        argstring=$(echo "$argstring" | sed -E "s/${target}/${replacement}/g")
+    else
+        # Append the replacement value if the target is not found in the original argstring.
+        argstring="$argstring $replacement"
+    fi
+    echo "$argstring"
+}
+# Validates capability to run $KDE_AUTO_ARGS
+# Returns 0 and logs if any dependency is missing.
+kde_auto_args_preflight() {
+    if [ -z "$SCB_KDE_AUTO_ARGS" ]; then
+        return 1
+    fi
+    local missing=""
+    # Check for KDE session
+    if [ -z "$KDE_FULL_SESSION" ]; then
+        missing+="KDE_FULL_SESSION not set; "
+    fi
+    # Check that jq is available
+    if ! command -v jq >/dev/null 2>&1; then
+        missing+="jq not available; "
+    fi
+    # Check that kscreen-doctor is available
+    if ! command -v kscreen-doctor >/dev/null 2>&1; then
+        missing+="kscreen-doctor not available; "
+    fi
+    if [ -n "$missing" ]; then
+        echo "SCB_KDE_AUTO_ARGS defined but not all required conditions are met: $missing"
+        return 1
+    fi
+    return 0
+}
+# Gets the user's primary display via kscreen-doctor.
+# Returns a single kscreen JSON object for the display obj.
+kde_get_primary_display() {
+    # if multidisplay, sort to get the "primary". KDE's settings panel
+    # has boolean style "primary" toggle, but kscreen uses a "priority" int value.
+    # If there's only one, we just get the first one.
+    kscreen-doctor -j | jq -c '
+        if (.outputs | length) == 1 then
+            .outputs[0]
+        else
+            (.outputs | map(select(.enabled == true)) | sort_by(.priority))[0]
+        end
+    '
+}
+# Selectively extracts mode info from kscreen doctor for use with KDE_AUTO_ARGS.
+# More fields are available on the mode, the jq selection can be updated if more
+# fields are needed later.
+kde_get_mode_info() {
+    # Ensure we're getting the enabled mode for the primary display
+    mode_id=$(kde_get_primary_display | jq -r '.currentModeId')
+    kde_get_primary_display | jq -r --arg mode_id "$mode_id" '
+        .modes[] | select(.id == $mode_id) | {width: .size.width, height: .size.height, refresh: .refreshRate}
+    '
+}
+
+
+#######
+# Main
+#######
+echo "Running ScopeBuddy version: $SCB_VER"
 # If SCB_NOSCOPE is set to 1 and we are not using a custom SCB_CONF
 if [ "$SCB_NOSCOPE" -eq 1 ] && [ "$SCB_CONF" == "scb.conf" ]; then
     # Use noscope.conf for default values
@@ -96,51 +194,8 @@ if [ -f "$SCB_CONFIGFILE" ]; then
         gamescope_opts=$SCB_GAMESCOPE_ARGS
     fi
 
-    # Helper func to fail fast if the user is trying to set KDE_AUTO_ARGS
-    # but doesn't have the right pre-reqs installed or isn't in KDE.
-    kde_auto_args_preflight() {
-        if [ -z "$SCB_KDE_AUTO_ARGS" ]; then
-            return 1
-        fi
-        local missing=""
-        # Check for KDE session
-        if [ -z "$KDE_FULL_SESSION" ]; then
-            missing+="KDE_FULL_SESSION not set; "
-        fi
-        # Check that jq is available
-        if ! command -v jq >/dev/null 2>&1; then
-            missing+="jq not available; "
-        fi
-        # Check that kscreen-doctor is available
-        if ! command -v kscreen-doctor >/dev/null 2>&1; then
-            missing+="kscreen-doctor not available; "
-        fi
-        if [ -n "$missing" ]; then
-            echo "SCB_KDE_AUTO_ARGS defined but not all required conditions are met: $missing"
-            return 1
-        fi
-        return 0
-    }
-
+    # kde_auto_args_preflight will fail fast if the user doesn't have deps installed.
     if kde_auto_args_preflight; then
-        # if multidisplay, sort to get the "primary". KDE settings uses 
-        # a boolean style "primary" toggle, but kscreen uses each display 
-        # with a "priority" int.
-        kde_get_primary_display() {
-            kscreen-doctor -j | jq -c '
-                if (.outputs | length) == 1 then
-                    .outputs[0]
-                else
-                    (.outputs | map(select(.enabled == true)) | sort_by(.priority))[0]
-                end
-            '
-        }
-        kde_get_mode_info() {
-            mode_id=$(kde_get_primary_display | jq -r '.currentModeId')
-            kde_get_primary_display | jq -r --arg mode_id "$mode_id" '
-                .modes[] | select(.id == $mode_id) | {width: .size.width, height: .size.height, refresh: .refreshRate}
-            '
-        }
         # hdr and vrr data are stored on the display
         KDE_HDR_STATE=$(kde_get_primary_display | jq -r '.hdr')
         KDE_VRR_STATE=$(kde_get_primary_display | jq -r '.vrrPolicy')
@@ -148,26 +203,14 @@ if [ -f "$SCB_CONFIGFILE" ]; then
         KDE_WIDTH=$(kde_get_mode_info | jq -r '.width')
         KDE_HEIGHT=$(kde_get_mode_info | jq -r '.height')
         KDE_REFRESH=$(kde_get_mode_info | jq -r '.refresh')
-
-        # Remove any existing width (-W), height (-H), or refresh (-r) flags from gamescope_opts.
-        # We will replace them with the inferred values from kscreen-doctor in a few lines.
-        if [ -n "$gamescope_opts" ]; then
-            gamescope_opts=$(echo "$gamescope_opts" | sed -E 's/ *-W[[:space:]]*[0-9]+//g; s/ *-H[[:space:]]*[0-9]+//g; s/ *-r[[:space:]]*[0-9]+//g')
-        fi
-        gamescope_opts="-W $KDE_WIDTH -H $KDE_HEIGHT -r $KDE_REFRESH"
+        gamescope_opts=$(replace_or_append_arg "$gamescope_opts" "-W[[:space:]]*[0-9]+" "-W $KDE_WIDTH")
+        gamescope_opts=$(replace_or_append_arg "$gamescope_opts" "-H[[:space:]]*[0-9]+" "-H $KDE_HEIGHT")
+        gamescope_opts=$(replace_or_append_arg "$gamescope_opts" "-r[[:space:]]*[0-9]+" "-r $KDE_REFRESH")
         if [[ "$KDE_HDR_STATE" == "true" ]]; then
-            if ! echo "$gamescope_opts" | grep -q -- '--hdr-enabled'; then
-                gamescope_opts="$gamescope_opts --hdr-enabled"
-            fi
+            gamescope_opts=$(verify_or_append_arg "$gamescope_opts" "--hdr-enabled")
         fi
-        # 1 and 2 captures "auto" and "always enabled" vrr modes
         if [[ "$KDE_VRR_STATE" == 1 || "$KDE_VRR_STATE" == 2 ]]; then
-            if ! echo "$gamescope_opts" | grep -q -- '--adaptive-sync'; then
-                gamescope_opts="$gamescope_opts --adaptive-sync"
-            fi
-            if ! echo "$gamescope_opts" | grep -q -- '--enable-vrr-modesetting'; then
-                gamescope_opts="$gamescope_opts --enable-vrr-modesetting"
-            fi
+            gamescope_opts=$(verify_or_append_arg "$gamescope_opts" "--adaptive-sync")
         fi
     fi
 

--- a/bin/scopebuddy
+++ b/bin/scopebuddy
@@ -296,7 +296,7 @@ else
               mv "$FILE.tmp" "$FILE"
             fi
         fi
-        echo "$LOGLINE" >> "$SCB_LOGFILE"
+        echo -e "$LOGLINE\n" >> "$SCB_LOGFILE"
     fi
     eval "env -u LD_PRELOAD $GAMESCOPE_BIN $gamescope_opts -- env LD_PRELOAD=$LD_PRELOAD_REAL $command"
 fi

--- a/bin/scopebuddy
+++ b/bin/scopebuddy
@@ -256,6 +256,8 @@ else
 #SCB_AUTO_HDR=1
 #SCB_AUTO_VRR=1
 #SCB_AUTO_FRAME_LIMIT=1
+# To debug scopebuddy output, uncomment the following line. After launching games, the executed cmd will be output to ~/.config/scopebuddy/scopebuddy.log
+#SCB_DEBUG=1
 ###
 ## FOR ADVANCED USE INSIDE AN APPID CONFIG
 ###
@@ -281,6 +283,20 @@ else
     LD_PRELOAD_REAL=$LD_PRELOAD
 
     # Unset LD_PRELOAD for gamescope (as it breaks the overlay) then start gamescope with LD_PRELOAD set for %command% instead
-    echo "Launching: env -u LD_PRELOAD $GAMESCOPE_BIN $gamescope_opts -- env LD_PRELOAD=$LD_PRELOAD_REAL $command"
+    LOGLINE="Launching: env -u LD_PRELOAD $GAMESCOPE_BIN $gamescope_opts -- env LD_PRELOAD=$LD_PRELOAD_REAL $command"
+    echo "$LOGLINE"
+    if [ "$SCB_DEBUG" -eq 1 ]; then
+        SCB_LOGFILE="$SCB_CONFIGDIR/scopebuddy.log"
+        if [ -f "$FILE" ]; then
+            # Count the total number of lines in the file
+            LINE_COUNT=$(wc -l < "$SCB_LOGFILE")
+            # If there are more than 100 lines, retain only the last 100 lines
+            if [ "$LINE_COUNT" -gt 100 ]; then
+              tail -n 100 "$FILE" > "$FILE.tmp"
+              mv "$FILE.tmp" "$FILE"
+            fi
+        fi
+        echo "$LOGLINE" >> "$SCB_LOGFILE"
+    fi
     eval "env -u LD_PRELOAD $GAMESCOPE_BIN $gamescope_opts -- env LD_PRELOAD=$LD_PRELOAD_REAL $command"
 fi

--- a/bin/scopebuddy
+++ b/bin/scopebuddy
@@ -207,15 +207,11 @@ if [ -f "$SCB_CONFIGFILE" ]; then
     PREFER_OUTPUT=$(echo "$gamescope_opts" | sed -nE 's/.*(-O|--prefer-output)[[:space:]]+([^[:space:]]+).*/\2/p')
     # kde_auto_args_preflight will fail fast if the user doesn't have deps installed.
     if [ "$SCB_AUTO_RES" -eq 1 ] && kde_auto_args_preflight; then
-        # width/height/refresh are mode-specifc values
+        # width/height are mode-specifc values
         KDE_WIDTH=$(kde_get_mode_info "$PREFER_OUTPUT" | jq -r '.width')
         KDE_HEIGHT=$(kde_get_mode_info "$PREFER_OUTPUT" | jq -r '.height')
         gamescope_opts=$(replace_or_append_arg "$gamescope_opts" "-W[[:space:]]*[0-9]+" "-W $KDE_WIDTH")
         gamescope_opts=$(replace_or_append_arg "$gamescope_opts" "-H[[:space:]]*[0-9]+" "-H $KDE_HEIGHT")
-    fi
-    if [ "$SCB_AUTO_FRAME_LIMIT" -eq 1 ] && kde_auto_args_preflight; then
-        KDE_REFRESH=$(kde_get_mode_info "$PREFER_OUTPUT" | jq -r '.refresh')
-        gamescope_opts=$(replace_or_append_arg "$gamescope_opts" "-r[[:space:]]*[0-9]+" "-r $KDE_REFRESH")
     fi
     if [ "$SCB_AUTO_HDR" -eq 1 ] && kde_auto_args_preflight; then
         KDE_HDR_STATE=$(kde_get_primary_display "$PREFER_OUTPUT" | jq -r '.hdr')
@@ -252,10 +248,10 @@ else
 # To not use this default set of arguments, just launch scb with SCB_NOSCOPE=1 or just add any gamescope argument before the '-- %command%' then this variable will be ignored
 #SCB_GAMESCOPE_ARGS="--mangoapp -f -w 2560 -h 1440 -W 2560 -H 1440 -r 180 --force-grab-cursor --hdr-enabled -e"
 #
-# To auto-detect KDE display width, height, refresh, VRR and HDR states, you can use SCB_AUTO_* {RES|FRAME_LIMIT|HDR|VRR}
-# This var will override any previously set values for -W, -H, -r with the correct values for your primary display, or
-# append --hdr-enabled and --adaptive-sync automatically depending on the current settings for your active display, or the display chosen
-# with -O / --prefer-output flags in gamescsope.
+# To auto-detect KDE display width, height, refresh, VRR and HDR states, you can use SCB_AUTO_* {RES|HDR|VRR}
+# These vars will override any previously set values for -W and -H or append --hdr-enabled and --adaptive-sync
+# automatically depending on the current settings for your active display, or the display chosen with -O /
+# --prefer-output flags in gamescsope.
 #SCB_AUTO_RES=1
 #SCB_AUTO_HDR=1
 #SCB_AUTO_VRR=1

--- a/bin/scopebuddy
+++ b/bin/scopebuddy
@@ -15,7 +15,7 @@
 #   "~/.config/scopebuddy/scb.conf" will be created with examples after first run
 # * Serve as a temporary workaround for fixing the steam overlay when using nested gamescope on desktop steam until fixed upstream
 set -eo pipefail
-SCB_VER="1.0.0"
+SCB_VER="1.0.1"
 echo "Running ScopeBuddy version: $SCB_VER"
 
 gamescope_opts=""
@@ -90,16 +90,127 @@ if [ -f "$SCB_CONFIGFILE" ]; then
         # shellcheck disable=SC1090
         source "$SCB_CONFIGDIR/AppID/${STEAM_APPID}.conf"
     fi
-
+  
     # If the user has supplied ANY args to gamescope, do not load the SCB_GAMESCOPE_ARGS
     if [ -z "$gamescope_opts" ]; then
         gamescope_opts=$SCB_GAMESCOPE_ARGS
     fi
+
+    kde_auto_args_preflight() {
+        if [ -z "$SCB_KDE_AUTO_ARGS" ]; then
+            return 1
+        fi
+        local missing=""
+        # Check for KDE session
+        if [ -z "$KDE_FULL_SESSION" ]; then
+            missing+="KDE_FULL_SESSION not set; "
+        fi
+        # Check that jq is available
+        if ! command -v jq >/dev/null 2>&1; then
+            missing+="jq not available; "
+        fi
+        # Check that kscreen-doctor is available
+        if ! command -v kscreen-doctor >/dev/null 2>&1; then
+            missing+="kscreen-doctor not available; "
+        fi
+        if [ -n "$missing" ]; then
+            echo "SCB_KDE_AUTO_ARGS defined but not all required conditions are met: $missing"
+            return 1
+        fi
+        return 0
+    }
+
+    # Don't bother trying to do KDE auto arg stuff unless we're in a KDE session,
+    # and have the env var specified and the deps installed.
+    if kde_auto_args_preflight; then
+        kde_get_current_mode_id() {
+            kde_get_screen_info | jq -r '
+                if (.outputs | length) == 1 then
+                    .outputs[0].currentModeId
+                else
+                    .outputs[] | select(.enabled == true and .primary == true) | .currentModeId
+                end
+            '
+        }
+
+        kde_get_mode_info() {
+            local mode_id="$1"
+            kde_get_screen_info | jq -r --arg mode_id "$mode_id" '
+                if (.outputs | length) == 1 then
+                    .outputs[0].modes[] | select(.id == $mode_id) | {width: .size.width, height: .size.height, refresh: .refreshRate}
+                else
+                    .outputs[] | select(.enabled == true and .primary == true) | .modes[] | select(.id == $mode_id) | {width: .size.width, height: .size.height, refresh: .refreshRate}
+                end
+            '
+        }
+        kde_get_hdr_state() {
+          kde_get_screen_info | jq -r '.outputs[] | select(.enabled == true) | .hdr'
+        }
+
+        # Function to get the VRR (adaptive sync) state of the enabled display
+        kde_get_vrr_state() {
+          kde_get_screen_info | jq -r '.outputs[] | select(.enabled == true) | .vrrPolicy'
+        }
+
+        # Function to get current screen information in JSON format
+        kde_get_screen_info() {
+          kscreen-doctor -j
+        }
+
+        # Extract width, height, and refresh rate from mode info for the enabled output
+        kde_get_width() {
+          echo "$1" | jq -r '.width'
+        }
+
+        kde_get_height() {
+          echo "$1" | jq -r '.height'
+        }
+
+        kde_get_refresh_rate() {
+          echo "$1" | jq -r '.refresh'
+        }
+        mode_id=$(kde_get_current_mode_id)
+        mode_info=$(kde_get_mode_info "$mode_id")
+
+        KDE_WIDTH=$(kde_get_width "$mode_info")
+        KDE_HEIGHT=$(kde_get_height "$mode_info")
+        KDE_REFRESH=$(kde_get_refresh_rate "$mode_info")
+
+        HDR_STATE=$(kde_get_hdr_state)
+        VRR_STATE=$(kde_get_vrr_state)
+
+        # Remove any existing width (-W), height (-H), or refresh (-r) flags from gamescope_opts.
+        # We will replace them with the inferred values from kscreen-doctor in a few lines.
+        if [ -n "$gamescope_opts" ]; then
+            gamescope_opts=$(echo "$gamescope_opts" | sed -E 's/ *-W[[:space:]]*[0-9]+//g; s/ *-H[[:space:]]*[0-9]+//g; s/ *-r[[:space:]]*[0-9]+//g')
+        fi
+
+        gamescope_opts="-W $KDE_WIDTH -H $KDE_HEIGHT -r $KDE_REFRESH"
+        if [[ "$HDR_STATE" == "true" ]]; then
+            if ! echo "$gamescope_opts" | grep -q -- '--hdr-enabled'; then
+                gamescope_opts="$gamescope_opts --hdr-enabled"
+            fi
+        fi
+
+        # 1 and 2 captures "auto" and "always enabled" vrr modes
+        if [[ "$VRR_STATE" == 1 || "$VRR_STATE" == 2 ]]; then
+            if ! echo "$gamescope_opts" | grep -q -- '--adaptive-sync'; then
+                gamescope_opts="$gamescope_opts --adaptive-sync"
+            fi
+            if ! echo "$gamescope_opts" | grep -q -- '--enable-vrr-modesetting'; then
+                gamescope_opts="$gamescope_opts --enable-vrr-modesetting"
+            fi
+        fi
+    fi
+
 else
     # Make the default config file
     if [ ! -d "$SCB_CONFIGDIR/AppID" ]; then
         mkdir -p "$SCB_CONFIGDIR/AppID"
     fi
+    # TODO: this content is functionally impossible to update for existing users, so it's maybe
+    # not a great place to stuff README-style content. Once the file is created they'll never get new
+    # versions on subsequent scopebuddy releases.
     cat << 'EOF' > "$SCB_CONFIGFILE"
 # This is the config file that let's you assign defaults for gamescope when using the scopebuddy script
 # lines starting with # are ignored
@@ -114,6 +225,10 @@ else
 # To not use this default set of arguments, just launch scb with SCB_NOSCOPE=1 or just add any gamescope argument before the '-- %command%' then this variable will be ignored
 #SCB_GAMESCOPE_ARGS="--mangoapp -f -w 2560 -h 1440 -W 2560 -H 1440 -r 180 --force-grab-cursor --hdr-enabled -e"
 #
+# To auto-detect KDE display width, height, refresh, VRR and HDR states, you can use SCB_KDE_AUTO_ARGS
+# This var will override any previously set values for -W, -H, -r with the correct values for your primary display.
+# It will also automaticallyand append --hdr-enabled and --adaptive-sync/--enable-vrr-modesetting depending on display support.
+#SCB_KDE_AUTO_ARGS=true
 ###
 ## FOR ADVANCED USE INSIDE AN APPID CONFIG
 ###

--- a/bin/scopebuddy
+++ b/bin/scopebuddy
@@ -188,14 +188,14 @@ if [ -f "$SCB_CONFIGFILE" ]; then
         # shellcheck disable=SC1090
         source "$SCB_CONFIGDIR/AppID/${STEAM_APPID}.conf"
     fi
-  
+
     # If the user has supplied ANY args to gamescope, do not load the SCB_GAMESCOPE_ARGS
     if [ -z "$gamescope_opts" ]; then
         gamescope_opts=$SCB_GAMESCOPE_ARGS
     fi
 
     # kde_auto_args_preflight will fail fast if the user doesn't have deps installed.
-    if kde_auto_args_preflight; then
+    if [ -n "$SCB_KDE_AUTO_ARGS" ] && kde_auto_args_preflight; then
         # hdr and vrr data are stored on the display
         KDE_HDR_STATE=$(kde_get_primary_display | jq -r '.hdr')
         KDE_VRR_STATE=$(kde_get_primary_display | jq -r '.vrrPolicy')

--- a/bin/scopebuddy
+++ b/bin/scopebuddy
@@ -294,16 +294,7 @@ else
     echo "$LOGLINE"
     if [ "$SCB_DEBUG" -eq 1 ]; then
         SCB_LOGFILE="$SCB_CONFIGDIR/scopebuddy.log"
-        if [ -f "$FILE" ]; then
-            # Count the total number of lines in the file
-            LINE_COUNT=$(wc -l < "$SCB_LOGFILE")
-            # If there are more than 100 lines, retain only the last 100 lines
-            if [ "$LINE_COUNT" -gt 100 ]; then
-              tail -n 100 "$FILE" > "$FILE.tmp"
-              mv "$FILE.tmp" "$FILE"
-            fi
-        fi
-        echo -e "$LOGLINE\n" >> "$SCB_LOGFILE"
+        echo -e "$LOGLINE" > "$SCB_LOGFILE"
     fi
     eval "env -u LD_PRELOAD $GAMESCOPE_BIN $gamescope_opts -- env LD_PRELOAD=$LD_PRELOAD_REAL $command"
 fi

--- a/bin/scopebuddy
+++ b/bin/scopebuddy
@@ -80,9 +80,6 @@ replace_or_append_arg() {
 # Validates capability to run $KDE_AUTO_ARGS
 # Returns 0 and logs if any dependency is missing.
 kde_auto_args_preflight() {
-    if [ -z "$SCB_KDE_AUTO_ARGS" ]; then
-        return 1
-    fi
     local missing=""
     # Check for KDE session
     if [ -z "$KDE_FULL_SESSION" ]; then
@@ -105,23 +102,34 @@ kde_auto_args_preflight() {
 # Gets the user's primary display via kscreen-doctor.
 # Returns a single kscreen JSON object for the display obj.
 kde_get_primary_display() {
-    # if multidisplay, sort to get the "primary". KDE's settings panel
-    # has boolean style "primary" toggle, but kscreen uses a "priority" int value.
-    # If there's only one, we just get the first one.
-    kscreen-doctor -j | jq -c '
-        if (.outputs | length) == 1 then
-            .outputs[0]
-        else
-            (.outputs | map(select(.enabled == true)) | sort_by(.priority))[0]
-        end
-    '
+    # we want to respect user settings for -O or --prefer-output.
+    # if so, jsut get that by name.
+    local prefer="$1"
+    if [ -n "$prefer" ]; then
+        # Try to select the output by its exact name
+        kscreen-doctor -j | jq -c --arg prefer "$prefer" '
+            .outputs | map(select(.name == $prefer)) | if length > 0 then .[0] else empty end
+        '
+    else
+        # if multidisplay, sort to get the "primary". KDE's settings panel
+        # has boolean style "primary" toggle, but kscreen uses a "priority" int value.
+        # If there's only one, we just get the first one.
+        kscreen-doctor -j | jq -c '
+            if (.outputs | length) == 1 then
+                .outputs[0]
+            else
+                (.outputs | map(select(.enabled == true)) | sort_by(.priority))[0]
+            end
+        '
+    fi
 }
 # Selectively extracts mode info from kscreen doctor for use with KDE_AUTO_ARGS.
 # More fields are available on the mode, the jq selection can be updated if more
 # fields are needed later.
 kde_get_mode_info() {
-    # Ensure we're getting the enabled mode for the primary display
-    mode_id=$(kde_get_primary_display | jq -r '.currentModeId')
+    local prefer="$1"
+    # Ensure we're getting the enabled mode for the primary display or the -o/--prefer-output value
+    mode_id=$(kde_get_primary_display "$prefer"| jq -r '.currentModeId')
     kde_get_primary_display | jq -r --arg mode_id "$mode_id" '
         .modes[] | select(.id == $mode_id) | {width: .size.width, height: .size.height, refresh: .refreshRate}
     '
@@ -194,21 +202,29 @@ if [ -f "$SCB_CONFIGFILE" ]; then
         gamescope_opts=$SCB_GAMESCOPE_ARGS
     fi
 
+    # Attempt to extract a preferred display from gamescope_opts.
+    # This sed command looks for either -O or --prefer-output followed by whitespace and a non‑space value.
+    PREFER_OUTPUT=$(echo "$gamescope_opts" | sed -nE 's/.*(-O|--prefer-output)[[:space:]]+([^[:space:]]+).*/\2/p')
     # kde_auto_args_preflight will fail fast if the user doesn't have deps installed.
-    if [ -n "$SCB_KDE_AUTO_ARGS" ] && kde_auto_args_preflight; then
-        # hdr and vrr data are stored on the display
-        KDE_HDR_STATE=$(kde_get_primary_display | jq -r '.hdr')
-        KDE_VRR_STATE=$(kde_get_primary_display | jq -r '.vrrPolicy')
+    if [ "$SCB_AUTO_RES" -eq 1 ] && kde_auto_args_preflight; then
         # width/height/refresh are mode-specifc values
-        KDE_WIDTH=$(kde_get_mode_info | jq -r '.width')
-        KDE_HEIGHT=$(kde_get_mode_info | jq -r '.height')
-        KDE_REFRESH=$(kde_get_mode_info | jq -r '.refresh')
+        KDE_WIDTH=$(kde_get_mode_info "$PREFER_OUTPUT" | jq -r '.width')
+        KDE_HEIGHT=$(kde_get_mode_info "$PREFER_OUTPUT" | jq -r '.height')
         gamescope_opts=$(replace_or_append_arg "$gamescope_opts" "-W[[:space:]]*[0-9]+" "-W $KDE_WIDTH")
         gamescope_opts=$(replace_or_append_arg "$gamescope_opts" "-H[[:space:]]*[0-9]+" "-H $KDE_HEIGHT")
+    fi
+    if [ "$SCB_AUTO_FRAME_LIMIT" -eq 1 ] && kde_auto_args_preflight; then
+        KDE_REFRESH=$(kde_get_mode_info "$PREFER_OUTPUT" | jq -r '.refresh')
         gamescope_opts=$(replace_or_append_arg "$gamescope_opts" "-r[[:space:]]*[0-9]+" "-r $KDE_REFRESH")
+    fi
+    if [ "$SCB_AUTO_HDR" -eq 1 ] && kde_auto_args_preflight; then
+        KDE_HDR_STATE=$(kde_get_primary_display "$PREFER_OUTPUT" | jq -r '.hdr')
         if [[ "$KDE_HDR_STATE" == "true" ]]; then
             gamescope_opts=$(verify_or_append_arg "$gamescope_opts" "--hdr-enabled")
         fi
+    fi
+    if [ "$SCB_AUTO_VRR" -eq 1 ] && kde_auto_args_preflight; then
+        KDE_VRR_STATE=$(kde_get_primary_display "$PREFER_OUTPUT" | jq -r '.vrrPolicy')
         if [[ "$KDE_VRR_STATE" == 1 || "$KDE_VRR_STATE" == 2 ]]; then
             gamescope_opts=$(verify_or_append_arg "$gamescope_opts" "--adaptive-sync")
         fi
@@ -236,10 +252,14 @@ else
 # To not use this default set of arguments, just launch scb with SCB_NOSCOPE=1 or just add any gamescope argument before the '-- %command%' then this variable will be ignored
 #SCB_GAMESCOPE_ARGS="--mangoapp -f -w 2560 -h 1440 -W 2560 -H 1440 -r 180 --force-grab-cursor --hdr-enabled -e"
 #
-# To auto-detect KDE display width, height, refresh, VRR and HDR states, you can use SCB_KDE_AUTO_ARGS
-# This var will override any previously set values for -W, -H, -r with the correct values for your primary display.
-# It will also automaticallyand append --hdr-enabled and --adaptive-sync/--enable-vrr-modesetting depending on display support.
-#SCB_KDE_AUTO_ARGS=true
+# To auto-detect KDE display width, height, refresh, VRR and HDR states, you can use SCB_AUTO_* {RES|FRAME_LIMIT|HDR|VRR}
+# This var will override any previously set values for -W, -H, -r with the correct values for your primary display, or
+# append --hdr-enabled and --adaptive-sync automatically depending on the current settings for your active display, or the display chosen
+# with -O / --prefer-output flags in gamescsope.
+#SCB_AUTO_RES=1
+#SCB_AUTO_HDR=1
+#SCB_AUTO_VRR=1
+#SCB_AUTO_FRAME_LIMIT=1
 ###
 ## FOR ADVANCED USE INSIDE AN APPID CONFIG
 ###


### PR DESCRIPTION
Apologies for the unsolicited pull request!

I've been maintaining my own bash script for gamescope management for a while, and I'm really excited to junk it now that scopebuddy replaces like 80% of the behavior of my script.

However, there was one major piece of functionality that I had in my gamescope manager that scopebuddy doesn't, which is automatic updating of display properties depending on my active/primary display in KDE.

I move my desktop on the weekends a lot to play games on my TV, which is a 4k display, whereas my display at my desk is a 3440x1440 ultrawide. I got really tired of having to update my gamescope args every time I moved it. Likewise, when I stream games with sunshine, I typically use my HDMI dummy plug, and if I'm streaming to a non-hdr enabled handheld like steam deck I have a `do` cmd bash script that sets the dummy plug display to 1280x800 + hdr off.

Anyway, all of that is to say: I think many users have use cases where they would like the machine running scope buddy to be able to dynamically set values for `-H`, `-W` and conditionally include or remove `--hdr-enabled` or `--enable-vrr` based on their context and not have to screw with their gamescope/scopebuddy config every time they change displays or virtual displays.

I don't know if you really see this type of functionality as something that you want to support in scopebuddy, but I figured I'd open a PR to at least start the conversation! I won't be offended if you decide it's not really a good fit :smile: 

Usage steps are:
- Add `SCB_AUTO_{RES|HDR|VRR}=1` to ~/.config/scopebuddy.conf 
- `scopebuddy -- glxgears`
- Debug echo should show values for `-H`, `-W`, `--adaptive-sync`, `--enable-hdr` that reflect the current KDE primary dispay
- If not KDE, everything should run as usual (no error)

Non-bazzite users will need to install JQ since I'm using it to parse kscreen output.

The most potentially brittle part is probably the sed stuff that tries to do targeted overrides of -H, -W, and -r. If you've got better ideas for how to approach that I'm all ears.

Thanks for all the hard work on scopebuddy!