### PR TITLE
feat: add SCB_PRE_COMMAND and SCB_POST_COMMAND  hooks

### DIFF
--- a/bin/scopebuddy
+++ b/bin/scopebuddy
@@ -276,6 +276,24 @@ else
 EOF
 fi
 
+
+pre_command() {
+  if [[ -n "$SCB_PRE_COMMAND" ]]; then
+    echo "Executing pre-command: $SCB_PRE_COMMAND"
+    eval "$SCB_PRE_COMMAND" || echo "Warning: SCB_PRE_COMMAND failed!"
+  fi
+}
+
+post_command() {
+  if [[ -n "$SCB_POST_COMMAND" ]]; then
+    echo "Executing post-command: $SCB_POST_COMMAND"
+    eval "$SCB_POST_COMMAND"
+  fi
+}
+
+# Bind post_command to exit signal
+trap post_command EXIT
+
 # If SCB_NOSCOPE is set to 1
 if [ "$SCB_NOSCOPE" -eq 1 ]; then
     # If we are potentially in gamemode
@@ -296,5 +314,7 @@ else
         SCB_LOGFILE="$SCB_CONFIGDIR/scopebuddy.log"
         echo -e "$LOGLINE" > "$SCB_LOGFILE"
     fi
+    # run pre_command before gamescope gets exec'd. will proceed even if pre_command fails.
+    pre_command
     eval "env -u LD_PRELOAD $GAMESCOPE_BIN $gamescope_opts -- env LD_PRELOAD=$LD_PRELOAD_REAL $command"
 fi

--- a/bin/scopebuddy
+++ b/bin/scopebuddy
@@ -20,7 +20,7 @@ set -eo pipefail
 # Globals
 ##########
 
-SCB_VER="1.1.0"
+SCB_VER="1.1.1"
 
 gamescope_opts=""
 command=""


### PR DESCRIPTION
This adds two config variables to scopebuddy: `SCB_PRE_COMMAND` and `SCB_POST_COMMAND`.

The idea is pretty simple: if you have some arbitrary shell commands you want to run before or after any time scopebuddy is run, this will run them.

`SCB_PRE_COMMAND` is currently written to ignore non-zero exit codes from the pre_command to prevent user footgun, but there's maybe a case to made that they'd rather know that their pre-command is failing (it would prevent gamescope from launching).

`SCB_POST_COMMAND` runs on a trap bound to `EXIT`, which should catch most signals gamescope gets from in-game exits, and potentially even force terminations of gamescope even?

Example scb.conf for testing:

```
SCB_GAMESCOPE_ARGS="-f --mangoapp"
SCB_AUTO_RES=1
SCB_AUTO_HDR=1
SCB_AUTO_VRR=1
SCB_DEBUG=1
SCB_PRE_COMMAND="tuned-adm profile throughput-performance-bazzite"
SCB_POST_COMMAND="tuned-adm profile balanced-bazzite"
```

Testing steps:

1. Apply config above (note that these are bazzite built-in tuned-ppd profiles - they should work on all bazzite systems unless you've been doing lots of modification of tuned/tuned-ppd
2. Run `scb -- glxgears`
3. alt+tab. Your power profile should be set to "performance"
4. Exit glxgears (esc)
5. Your power profile should be reset back to balanced.