### PR TITLE
fix: Check for nested gamescope via environment variable

### DIFF
--- a/bin/scopebuddy
+++ b/bin/scopebuddy
@@ -156,7 +156,7 @@ fi
 
 # If steam is potentially running inside gamescope
 # shellcheck disable=SC2009
-if ps ax | grep -P "steam.sh -.+ -steampal" | grep -v grep || pgrep -f "gamescope-session" ; then
+if ps ax | grep -P "steam.sh -.+ -steampal" | grep -v grep || [ "$XDG_CURRENT_DESKTOP" = "gamescope" ] ; then
     # If steam is potentially running in gamemode
     # Force SCB_NOSCOPE to 1
     SCB_NOSCOPE=1


### PR DESCRIPTION
Gamescope sets [`XDG_CURRENT_DESKTOP=gamescope`](https://github.com/ValveSoftware/gamescope/blob/6eb7398d1a4cc36e466931a4865b64f7a94658df/src/main.cpp#L999) for everything running under it. Should make for a more robust method of checking for the nested case.

Tested successfully launching a game within ScopeBuddy, both running Steam within gamescope on Plasma, and outside gamescope on Plasma.