### PR TITLE
fix: Handle gamescope not being present

### DIFF
--- a/bin/scopebuddy
+++ b/bin/scopebuddy
@@ -380,6 +380,14 @@ nonsteam_appid_detect() {
 # Main
 #######
 echo "Running ScopeBuddy version: $SCB_VER"
+
+# If gamescope is not found, force SCB_NOSCOPE to 1
+if ! command -v "$GAMESCOPE_BIN" >/dev/null 2>&1; then
+    echo "Setting SCB_NOSCOPE=1 because gamescope was not found"
+    SCB_NOSCOPE=1
+fi
+
+
 # If SCB_NOSCOPE is set to 1 and we are not using a custom SCB_CONF
 if [ "$SCB_NOSCOPE" -eq 1 ] && [ "$SCB_CONF" == "scb.conf" ]; then
     # Use noscope.conf for default values


### PR DESCRIPTION
When gamescope is not present on the system and SCB_NOSCOPE does not equal 1, scopebuddy does not launch anything.

Current behavior without gamescope present (tested in a virtual machine and distrobox, program does not launch):
```
Running ScopeBuddy version: 1.2.5
Launching: env -u LD_PRELOAD gamescope  -- env LD_PRELOAD=  "glxgears"
bash: gamescope: command not found
```

New behavior (program does launch):
```
Running ScopeBuddy version: 1.2.5
Setting SCB_NOSCOPE=1 because gamescope was not found
```