### PR TITLE
feat: introduce SCB_NESTEDFIX as a variable

### DIFF
--- a/bin/scopebuddy
+++ b/bin/scopebuddy
@@ -68,6 +68,7 @@ SCB_AUTO_FRAME_LIMIT=${SCB_AUTO_FRAME_LIMIT:-0}
 SCB_STEAMARGIGNORE=${SCB_STEAMARGIGNORE:-1}
 
 # Add a variable to disable the fix for the steam overlay and steam input in nested gamescope
+# See https://xkcd.com/1172/
 SCB_NESTEDFIX=${SCB_NESTEDFIX:-1}
 
 ############


### PR DESCRIPTION
This variable will be set to `1` by default, however a user can set this to `0` to disable the `LD_PRELOAD` fix that scopebuddy applies to gamescope executions so you can use it to bypass broken or less ideal steam input implementations in games and instead use the "Desktop" layout for steam input.
NOTE: user will have to manually set the desktop layout to "gamepad" or a similar layout they want to use.

PR also fixes the lack of a logline being added when scopebuddy runs in gamemode or noscope mode