### PR TITLE
refactor: remove perl dependency using sed

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,6 @@ SCB_AUTO_RES=1 scopebuddy -O DP-3 -- %command%
 ### Requirements
 * bash
 * [gamescope](https://github.com/ValveSoftware/gamescope)
-* perl
 
 Optional for `$SCB_AUTO_RES`/`$SCB_AUTO_HDR`/`$SCB_AUTO_VRR`:
 * **KDE Plasma**: `kscreen-doctor` (usually pre-installed) and `jq` (installed by default on Bazzite)

--- a/bin/scopebuddy
+++ b/bin/scopebuddy
@@ -402,13 +402,13 @@ nonsteam_appid_detect() {
         # Set APPID_FOLDER
         APPID_FOLDER="ubisoft"
         # Set auto appid
-        AUTO_APPID="$APPID_FOLDER/"$(echo "$command" | perl -pe 's/.+"uplay:\/\/launch\/(\d+)"\s+/\1/')
+        AUTO_APPID="$APPID_FOLDER/"$(echo "$command" | sed -E 's/.+"uplay:\/\/launch\/([0-9]+)"[[:space:]]+/\1/')
     # Detect games launched by Heroic Games Launcher
     elif echo "$command" | grep "heroic://" > /dev/null; then
         # Set APPID_FOLDER
         APPID_FOLDER="heroic"
         # Set auto appid
-        AUTO_APPID="$APPID_FOLDER/"$(echo "$command" | perl -pe 's/.+"heroic:\/\/launch\?appName=(.+)&.+\s+/\1/')
+        AUTO_APPID="$APPID_FOLDER/"$(echo "$command" | sed -E 's/.+"heroic:\/\/launch\?appName=([^&]+)&.+[[:space:]]+/\1/')
     fi
 
     # Make config folder
@@ -489,7 +489,7 @@ done
 # If $SCB_APPID is not set, attempt to auto detect APPID for Steam
 if [ -z "$SCB_APPID" ]; then
     # Get the Steam APPID from %command%
-    AUTO_APPID=$(echo "$command" | perl -pe 's/.+"AppId=(\d+)"\s.+/\1/')
+    AUTO_APPID=$(echo "$command" | sed -E 's/.+"AppId=([0-9]+)"[[:space:]].+/\1/')
     if ! [[ $AUTO_APPID =~ ^[0-9]+$ ]]; then
         AUTO_APPID=$(nonsteam_appid_detect "$command" "$SCB_CONFIGDIR")
     fi

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,6 @@
             wrapProgram $out/bin/scopebuddy \
               --prefix PATH : ${pkgs.lib.makeBinPath [
                 pkgs.gamescope
-                pkgs.perl
                 pkgs.jq
                 pkgs.wlr-randr
               ]}


### PR DESCRIPTION
This removes the dependency on perl in the script. `sed -E` is used elsewhere so this should not break compatibility. It also modifies the heroic regex to stop on the first `&` so it does not capture extra arguments.

Motivation is I have a custom recipe.yml and was surprised this broke when I removed perl.

Tested locally using steam and heroic.